### PR TITLE
Deploy version 4.5.1 of opencv

### DIFF
--- a/setup_opencv.sh
+++ b/setup_opencv.sh
@@ -4,7 +4,7 @@ set -e
 
 # Download OpenCV Android SDK
 
-opencv_version="4.4.0"
+opencv_version="4.5.1"
 opencv_sdk_zip="cache/opencv-android-sdk.zip"
 
 if [[ $1 = "--skip-download" ]]; then


### PR DESCRIPTION
Hey some new version of opencv have been released since the last one built on your repos, would it be possible to add them at least the last one?

It's so much easier and friendly to import it from gradle than from source. Thanks for the work anyway.